### PR TITLE
Module gitpython is not in requirements file. Add it.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.12.4
 six==1.10.0
 websocket-client==0.40.0
 wheel==0.24.0
+gitpython==2.1.1


### PR DESCRIPTION
When running `simplej --help` the result is an ImportError

   $simplej --help
   ...
   ImportError: No module named 'git'